### PR TITLE
Replace render functions w/ onElementAdded

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import App from "./ui/app/App";
-import { renderElement } from "./ui/rendering";
 
 const app = document.createElement("div");
 document.body.append(app);
-renderElement(app, App());
+app.outerHTML = App();

--- a/src/ui/app/App.ts
+++ b/src/ui/app/App.ts
@@ -20,8 +20,6 @@ with this program. If not, see <https://www.gnu.org/licenses/>.
 import { loadDeck } from "../../business/dataAccess";
 import Board from "../board/Board";
 import {
-  runAfterRender,
-  renderElement,
   canDrag,
   canDrop,
   drop,
@@ -31,6 +29,7 @@ import {
   endDrag,
   onCanDropUnhover,
   onCanDropHover,
+  onElementAdded,
 } from "../rendering";
 import { html } from "../templateLiterals";
 
@@ -153,21 +152,15 @@ const App = (): string => {
   const appId = "app";
   const boardId = "board";
 
-  runAfterRender(() => {
-    const app = document.getElementById(appId);
-    if (!app) {
-      throw new Error("Missing app element");
-    }
+  onElementAdded(appId, (app) => {
     app.addEventListener("pointerdown", onPointerDown);
     app.addEventListener("pointermove", onPointerMove);
     app.addEventListener("pointerup", onPointerUp);
+  });
 
+  onElementAdded(boardId, (board) => {
     loadDeck().then((boardModel) => {
-      const board = document.getElementById(boardId);
-      if (!board) {
-        throw new Error("Missing board element");
-      }
-      renderElement(board, Board(boardModel));
+      board.outerHTML = Board(boardModel);
     });
   });
 

--- a/src/ui/board/Board.ts
+++ b/src/ui/board/Board.ts
@@ -28,13 +28,12 @@ import {
   CardSide,
 } from "../../business/models";
 import EmptySpace from "../emptySpace/EmptySpace";
-import Card, { updateCardZIndex, updateCardZIndexById } from "../card/Card";
+import Card, { updateCardZIndex } from "../card/Card";
 import {
-  runAfterRender,
-  renderElement,
   registerDraggable,
   registerDropTarget,
   getNextZIndex,
+  onElementAdded,
 } from "../rendering";
 import { html } from "../templateLiterals";
 import styles from "./Board.module.css";
@@ -182,11 +181,11 @@ const Board = (boardModel: BoardModel): string => {
 
     const canDrag = (): boolean => boardModel.canMoveCard(cardDealt.card);
 
-    runAfterRender(() => {
-      updateCardZIndexById(cardDealt.card.id, getNextZIndex());
+    onElementAdded(cardDealt.card.id, (card) => {
+      updateCardZIndex(card, getNextZIndex());
     });
 
-    renderElement(card, Card(cardDealt.card, classNames));
+    card.outerHTML = Card(cardDealt.card, classNames);
     registerDraggable(
       cardDealt.card.id,
       canDrag,
@@ -214,16 +213,13 @@ const Board = (boardModel: BoardModel): string => {
       board?.appendChild(emptySpace);
 
       const emptySpaceId = createId("emptySpace");
-      renderElement(
-        emptySpace,
-        EmptySpace(emptySpaceId, [
-          styles.space,
-          ...getCardClassNamesForPosition({
-            column: spaceLeftEmpty.position.column,
-            row: spaceLeftEmpty.position.row,
-          }),
-        ])
-      );
+      emptySpace.outerHTML = EmptySpace(emptySpaceId, [
+        styles.space,
+        ...getCardClassNamesForPosition({
+          column: spaceLeftEmpty.position.column,
+          row: spaceLeftEmpty.position.row,
+        }),
+      ]);
       registerDropTarget(
         emptySpaceId,
         (draggableId: string) => {
@@ -299,7 +295,7 @@ const Board = (boardModel: BoardModel): string => {
     });
   });
 
-  runAfterRender(boardModel.dealCards);
+  onElementAdded(boardId, () => boardModel.dealCards());
 
   let initialCards = "";
   for (let column = 0; column < maxBoardColumns; ++column) {

--- a/src/ui/card/Card.ts
+++ b/src/ui/card/Card.ts
@@ -34,13 +34,6 @@ const getCombinedClassName = (
   return classNames.join(" ");
 };
 
-export const updateCardZIndexById = (cardId: string, zIndex: number): void => {
-  const cardElement = document.getElementById(cardId);
-  if (cardElement) {
-    updateCardZIndex(cardElement, zIndex);
-  }
-};
-
 export const updateCardZIndex = (
   cardElement: HTMLElement,
   zIndex: number

--- a/src/ui/rendering.ts
+++ b/src/ui/rendering.ts
@@ -17,24 +17,19 @@ You should have received a copy of the GNU Affero General Public License along
 with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-const runAfterRenderQueue: (() => void)[] = [];
-
-export const runAfterRender = (callback: () => void): void => {
-  runAfterRenderQueue.push(callback);
-};
-
-const flushRunAfterRenderQueue = (): void => {
-  while (runAfterRenderQueue.length) {
-    const callback = runAfterRenderQueue.shift();
-    if (callback) {
-      callback();
+export const onElementAdded = (
+  id: string,
+  callback: (element: HTMLElement) => void
+): void => {
+  const observer = new MutationObserver(() => {
+    const element = document.getElementById(id);
+    if (element) {
+      observer.disconnect();
+      callback(element);
+      return;
     }
-  }
-};
-
-export const renderElement = (element: Element, outerHtml: string): void => {
-  element.outerHTML = outerHtml;
-  flushRunAfterRenderQueue();
+  });
+  observer.observe(document.getRootNode(), { subtree: true, childList: true });
 };
 
 export interface Style {


### PR DESCRIPTION
Replaces `renderElement` and `runAfterRender` with `onElementAdded`, so we can execute a callback when an element with a certain ID is added without having to remember to use `renderElement`.