### PR TITLE
Drag items onto player to use

### DIFF
--- a/src/business/effects.ts
+++ b/src/business/effects.ts
@@ -34,14 +34,18 @@ export abstract class OneTimeEffect extends Effect {
 }
 
 export abstract class ModifierEffect extends Effect {
-  amount: number | undefined;
+  amount: number;
 
   protected constructor(
     id: string,
     name: string,
     description: string,
-    amount?: number
+    amount: number
   ) {
+    if (amount < 1) {
+      throw new Error(`Creating effect ${name} with non-positive amount`);
+    }
+
     super(id, name, description);
     this.amount = amount;
   }
@@ -86,11 +90,8 @@ export const createModifierEffect = (
 };
 
 export class FatigueEffect extends ModifierEffect {
-  readonly amount: number;
-
   constructor(id: string, amount: number) {
-    super(id, "Fatigue", `Reduces strength by ${amount}`);
-    this.amount = amount;
+    super(id, "Fatigue", `Reduces strength by ${amount}`, amount);
   }
 
   override getStrengthModifier(): number {

--- a/src/business/effects.ts
+++ b/src/business/effects.ts
@@ -1,0 +1,43 @@
+/*
+Copyright (C) 2024 Jesdo Software LLC.
+
+This file is part of Roguish.
+
+Roguish is free software: you can redistribute it and/or modify it
+under the terms of the GNU Affero General Public License as published by the
+Free Software Foundation, either version 3 of the License, or (at your option)
+any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { ItemEffect, MonsterCardModel, MonsterItemEffect } from "./models";
+
+export const createEffect = (id: string, ...params: number[]): ItemEffect => {
+  switch (id) {
+    case "food":
+      return new FoodEffect(id, params[0]);
+    default:
+      throw new Error(`Unknown effect ID ${id}`);
+  }
+};
+
+class FoodEffect extends MonsterItemEffect {
+  readonly toStrength: number;
+
+  constructor(id: string, toStrength: number) {
+    super(id, "Food", `Increase strength by ${toStrength}, up to the maximum`);
+    this.toStrength = toStrength;
+  }
+
+  apply(monster: MonsterCardModel): void {
+    const strengthToMax = monster.maxStrength - monster.strength;
+    monster.strength += Math.min(this.toStrength, strengthToMax);
+  }
+}

--- a/src/business/effects.ts
+++ b/src/business/effects.ts
@@ -56,6 +56,7 @@ export abstract class ModifierEffect extends Effect {
 }
 
 export interface Affected {
+  activeEffects: readonly ModifierEffect[];
   addActiveEffect: (effect: ModifierEffect) => void;
   removeActiveEffect: (id: string, amount?: number) => void;
 }

--- a/src/business/effects.ts
+++ b/src/business/effects.ts
@@ -27,9 +27,7 @@ export abstract class Effect {
     this.name = name;
     this.description = description;
   }
-}
 
-export abstract class OneTimeEffect extends Effect {
   abstract apply(affected: Affected): void;
 }
 
@@ -50,6 +48,10 @@ export abstract class ModifierEffect extends Effect {
     this.amount = amount;
   }
 
+  override apply(affected: Affected): void {
+    affected.addActiveEffect(this);
+  }
+
   getStrengthModifier(): number {
     return 0;
   }
@@ -65,25 +67,12 @@ export interface Affected {
   removeActiveEffect: (id: string, amount?: number) => void;
 }
 
-export const createOneTimeEffect = (
-  id: string,
-  amount: number
-): OneTimeEffect => {
-  switch (id) {
-    case "food":
-      return new FoodEffect(id, amount);
-    default:
-      throw new Error(`Unknown effect ID ${id}`);
-  }
-};
-
-export const createModifierEffect = (
-  id: string,
-  amount: number
-): ModifierEffect => {
+export const createEffect = (id: string, amount: number): Effect => {
   switch (id) {
     case "fatigue":
       return new FatigueEffect(id, amount);
+    case "food":
+      return new FoodEffect(id, amount);
     default:
       throw new Error(`Unknown effect ID ${id}`);
   }
@@ -99,7 +88,7 @@ export class FatigueEffect extends ModifierEffect {
   }
 }
 
-export class FoodEffect extends OneTimeEffect {
+export class FoodEffect extends Effect {
   readonly amount: number;
 
   constructor(id: string, amount: number) {

--- a/src/business/models.ts
+++ b/src/business/models.ts
@@ -175,7 +175,7 @@ export class MonsterCardModel extends CardModel {
 
   private readonly equipment: ItemCardModel[] = [];
 
-  get strength(): number {
+  getStrength(): number {
     const sumStrengthModifiers = (affected: Affected): number => {
       let strength = 0;
       for (const activeEffect of affected.activeEffects) {
@@ -192,7 +192,7 @@ export class MonsterCardModel extends CardModel {
     return strength;
   }
 
-  get maxStrength(): number {
+  getMaxStrength(): number {
     // calculate from active effects
     return this.intrinsicStrength;
   }
@@ -224,7 +224,7 @@ export class MonsterCardModel extends CardModel {
     bindPrototypeMethods(this);
 
     this.activeEffectsChanged.addListener(() => {
-      if (this.strength <= 0) {
+      if (this.getStrength() <= 0) {
         this.die("exhaustion");
       }
     });
@@ -274,7 +274,10 @@ export class MonsterCardModel extends CardModel {
 
   attack(target: MonsterCardModel): void {
     if (this.combat > target.combat) {
-      const fatigueEffect = createModifierEffect("fatigue", target.strength);
+      const fatigueEffect = createModifierEffect(
+        "fatigue",
+        target.getStrength()
+      );
       this.addActiveEffect(fatigueEffect);
 
       target.die(this.name);

--- a/src/business/models.ts
+++ b/src/business/models.ts
@@ -158,6 +158,10 @@ export class ItemCardModel extends CardModel {
 
     bindPrototypeMethods(this);
   }
+
+  applyEffects(target: CardModel): void {
+    this.effects.forEach((effect) => effect.apply(target));
+  }
 }
 
 export function isItemCard(card: CardModel): card is ItemCardModel {

--- a/src/data/dtos.ts
+++ b/src/data/dtos.ts
@@ -25,10 +25,16 @@ export interface CardDefDto {
 const equipmentTypes = ["head", "body", "held", "offhand"] as const;
 type EquipmentType = (typeof equipmentTypes)[number];
 
+export interface EffectDto {
+  id: string;
+  amount: number;
+}
+
 export interface ItemCardDefDto extends CardDefDto {
   cardType: "item";
   equipmentTypes?: EquipmentType[];
   combat?: number;
+  effects?: EffectDto[];
 }
 
 export const isItemCardDefDto = (
@@ -70,6 +76,15 @@ const validateCardDefDto = (cardDefDto: CardDefDto): void => {
   }
 };
 
+const validateEffectDto = (effectDto: EffectDto): void => {
+  if (!effectDto.id) {
+    throw new Error("Effect missing ID");
+  }
+  if (!effectDto.amount) {
+    throw new Error(`Effect ${effectDto.id} missing amount`);
+  }
+};
+
 const validateItemCardDefDto = (cardDefDto: ItemCardDefDto): void => {
   validateCardDefDto(cardDefDto);
 
@@ -81,6 +96,9 @@ const validateItemCardDefDto = (cardDefDto: ItemCardDefDto): void => {
         );
       }
     });
+  }
+  if (cardDefDto.effects) {
+    cardDefDto.effects.forEach((effect) => validateEffectDto(effect));
   }
 };
 

--- a/src/ui/board/Board.ts
+++ b/src/ui/board/Board.ts
@@ -165,7 +165,6 @@ const Board = (
   const canDropCard = (draggableId: string, dropTargetId: string): boolean => {
     const cardFromBoard = boardModel.getCardByIdIfExists(draggableId);
     const cardFromHand = handModel.getCardByIdIfExists(draggableId);
-
     if (cardFromBoard) {
       const dropTarget = boardModel.getCardById(dropTargetId);
       const dropTargetPosition = boardModel.getCardPosition(dropTarget);
@@ -174,7 +173,9 @@ const Board = (
         row: dropTargetPosition.row,
       });
     } else if (cardFromHand) {
-      return false; // TODO implement
+      // TODO check if drop target is valid for card from hand
+      // TODO allow throwing
+      return dropTargetId === boardModel.playerCard.id;
     } else {
       return false;
     }
@@ -195,11 +196,21 @@ const Board = (
   };
 
   const onDropCard = (draggableId: string, dropTargetId: string): void => {
-    const droppedCard = boardModel.getCardById(draggableId);
     const dropTarget = boardModel.getCardById(dropTargetId);
     const dropTargetPosition = boardModel.getCardPosition(dropTarget);
 
-    boardModel.moveCard(droppedCard, dropTargetPosition);
+    const cardFromBoard = boardModel.getCardByIdIfExists(draggableId);
+    const cardFromHand = handModel.getCardByIdIfExists(draggableId);
+    if (cardFromBoard) {
+      boardModel.moveCard(cardFromBoard, dropTargetPosition);
+    } else if (cardFromHand) {
+      cardFromHand.applyEffects(dropTarget);
+      handModel.removeCard(cardFromHand.id);
+
+      const cardElem = getElementById(cardFromHand.id);
+      cardElem.classList.remove(boardStyles.inHand);
+      cardElem.classList.add(boardStyles.discarded);
+    }
   };
 
   const dealCard = (cardDealt: CardDealtEventArgs): void => {
@@ -355,6 +366,13 @@ const Board = (
             () => boardModel.canMoveCard(cardModel),
             onDragCardStart,
             onDragCardEnd
+          );
+          registerDropTarget(
+            card.id,
+            canDropCard,
+            onCanDropHover,
+            onCanDropUnhover,
+            onDropCard
           );
         });
       }

--- a/src/ui/board/Board.ts
+++ b/src/ui/board/Board.ts
@@ -208,8 +208,7 @@ const Board = (
       handModel.removeCard(cardFromHand.id);
 
       const cardElem = getElementById(cardFromHand.id);
-      cardElem.classList.remove(boardStyles.inHand);
-      cardElem.classList.add(boardStyles.discarded);
+      removeElementAfterDuration(cardElem, 0);
     }
   };
 

--- a/src/ui/card/Card.ts
+++ b/src/ui/card/Card.ts
@@ -82,12 +82,10 @@ const Card = (
       combatElem.innerText = `${cardModel.combat}`;
     });
 
-    const onActiveEffectsChanged = (): void => {
+    cardModel.activeEffectsChanged.addListener(() => {
       const strengthElem = getElementById(strengthId);
       strengthElem.innerHTML = getStrengthDisplay();
-    };
-
-    cardModel.activeEffectsChanged.addListener(onActiveEffectsChanged);
+    });
 
     monsterProperties = html`
       <dl>

--- a/src/ui/card/Card.ts
+++ b/src/ui/card/Card.ts
@@ -69,10 +69,13 @@ const Card = (
     const combatId = createId();
     const strengthId = createId();
 
-    const getStrengthDisplay = (): string =>
-      alwaysShowMaxStrength || cardModel.strength !== cardModel.maxStrength
-        ? `${cardModel.strength} / ${cardModel.maxStrength}`
-        : `${cardModel.strength}`;
+    const getStrengthDisplay = (): string => {
+      const strength = cardModel.getStrength();
+      const maxStrength = cardModel.getMaxStrength();
+      return alwaysShowMaxStrength || strength !== maxStrength
+        ? `${strength} / ${maxStrength}`
+        : `${strength}`;
+    };
 
     cardModel.combatChanged.addListener(() => {
       const combatElem = getElementById(combatId);

--- a/src/ui/card/Card.ts
+++ b/src/ui/card/Card.ts
@@ -71,10 +71,7 @@ const Card = (
 
     const getStrengthDisplay = (): string =>
       alwaysShowMaxStrength || cardModel.strength !== cardModel.maxStrength
-        ? html`
-            <span>${cardModel.strength}</span> /
-            <span>${cardModel.maxStrength}</span>
-          `
+        ? `${cardModel.strength} / ${cardModel.maxStrength}`
         : `${cardModel.strength}`;
 
     cardModel.combatChanged.addListener(() => {
@@ -82,13 +79,12 @@ const Card = (
       combatElem.innerText = `${cardModel.combat}`;
     });
 
-    const onStrengthChanged = (): void => {
+    const onActiveEffectsChanged = (): void => {
       const strengthElem = getElementById(strengthId);
       strengthElem.innerHTML = getStrengthDisplay();
     };
 
-    cardModel.strengthChanged.addListener(onStrengthChanged);
-    cardModel.maxStrengthChanged.addListener(onStrengthChanged);
+    cardModel.activeEffectsChanged.addListener(onActiveEffectsChanged);
 
     monsterProperties = html`
       <dl>

--- a/src/ui/hand/Hand.ts
+++ b/src/ui/hand/Hand.ts
@@ -17,7 +17,7 @@ You should have received a copy of the GNU Affero General Public License along
 with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { HandModel, createId } from "../../business/models";
+import { HandModel } from "../../business/models";
 import Card from "../card/Card";
 import { registerDraggable } from "../dragDrop";
 import { html } from "../templateLiterals";
@@ -46,12 +46,11 @@ const Hand = (
       <ul class="${commonStyles.cardList}">
         ${Array.from(handModel.cards.values())
           .map((cardModel) => {
-            const id = createId();
-            onElementAdded(id, (cardElem) => {
+            onElementAdded(cardModel.id, (cardElem) => {
               registerDraggable(cardElem, () => true, onDragStart, onDragEnd);
             });
             return html`<li>
-              ${Card(id, cardModel, false, [commonStyles.draggable])}
+              ${Card(cardModel.id, cardModel, false, [commonStyles.draggable])}
             </li>`;
           })
           .join("")}


### PR DESCRIPTION
Adds an effect system with two types of effect: one-time and modifier. Applies an item's effects to the player when an item card is dragged from the hand onto the player card.

Also implements strength damage (incurred after winning a fight) in terms of a fatigue modifier effect. Food item cards heal fatigue.

Closes #53 